### PR TITLE
Fix home screen scroll and warnings

### DIFF
--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useState } from 'react';
 import { Text, View, Image, Pressable, ScrollView } from 'react-native'
 import EStyleSheet from 'react-native-extended-stylesheet';
@@ -81,11 +81,12 @@ const selectedBarPos = 0;
 
 function HomeScreen({ navigation }) {
   const [selectedCategory, setSelectedCategory] = useState(0);
+  const scrollViewRef = useRef(null);
 
   const [subheadings, cardContent] = facilities.reduce(
     (acc, { category, locations }, index) => {
       acc[0].push(
-        <Pressable key={index} onPress={() => setSelectedCategory(index)}>
+        <Pressable key={index} onPress={() => {setSelectedCategory(index); scrollViewRef.current.scrollTo({x: 0, y: 0, animated: false})}}>
           <Text style={styles.featuredSubheading}>{category}</Text>
           <View style={[styles.selectedBar, {display: selectedCategory == index ? 'flex' : 'none'}]} />
         </Pressable>
@@ -137,6 +138,7 @@ function HomeScreen({ navigation }) {
         </View>
         <View style={styles.cardContainer}>
           <ScrollView
+            ref={scrollViewRef}
             style={styles.scrollViewStyle}
             contentContainerStyle={styles.scrollViewContent}
             horizontal={true}
@@ -377,6 +379,7 @@ const styles = EStyleSheet.create({
   },
   cardArrowCircle: {
     position: 'absolute',
+    backgroundColor: 'white',
     right: '4%',
     top: '48.42%',
     borderRadius: 50,


### PR DESCRIPTION
## Problem

Bug fixes in Home screen:
- When going to a new tab in the `Featured Centres` section, scroll does not reset, which can lead to scenarios where if the new tab has less cards than the previous tab, they will be displayed having been scrolled off the screen.
- iOS warnings about shadows being calculated inefficiently are due to shadows being calculated based off children rather than the current view

## Description of Changes

- the `onPress` methods of the `Featured Centres` tabs now reset the card scrollview back to 0 instantly
- Added background colour to the relevant views to fix shadow warnings (invisible because children fill the view entirely)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
