### PR TITLE
Create custom Button component

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import EStyleSheet from "react-native-extended-stylesheet";
+
+import type { PressableProps } from 'react-native';
+
+interface ButtonProps {
+    transparentShadow?: boolean,
+    shadow?: boolean,
+    center?: string,
+    style: any|any[],
+    children: React.ReactNode,
+}
+
+const Button = ({ transparentShadow = false, shadow = false, center = '', children, style = { backgroundColor: 'white', buttonColor: 'white' }, ...props }: ButtonProps&PressableProps) => {
+    let flatStyle = StyleSheet.flatten(style);
+
+    return (
+        <>
+            {transparentShadow ? <View style={[styles.shadow, flatStyle, { backgroundColor: flatStyle.backgroundColor }]} /> : <></>}
+            <Pressable
+                style={[flatStyle, shadow&&!transparentShadow ? styles.shadow : null, { backgroundColor: transparentShadow ? flatStyle.buttonColor : flatStyle.backgroundColor, zIndex: 1000 }]}
+                {...props}>
+                <View
+                    style={[styles.buttonContainer,
+                    {
+                        alignItems: center.includes('v') ? 'center' : 'stretch',
+                        justifyContent: center.includes('h') ? 'center' : 'flex-start'
+                    }]}>
+                    {children}
+                </View>
+            </Pressable>
+        </>
+    );
+}
+
+const styles = EStyleSheet.create({
+    shadow: {
+        shadowOffset: { width: 1, height: 4 },
+        shadowRadius: 4,
+        shadowColor: 'rgba(0, 0, 0, 0.6)',
+        shadowOpacity: 0.1,
+        elevation: 3,
+    },
+    buttonContainer: {
+        flexDirection: 'row',
+        width: '100%',
+        height: '100%',
+    },
+});
+
+export default Button;


### PR DESCRIPTION
## Problem

Most button-type views have the following in common:
- need for centering (horizontally or vertically)
- shadows

This PR creates a custom `Pressable` that has centering and shadows built in, even if the button in question is transparent.

Close #11.

## Description of Changes

Creates a new custom `Button` component. Centering can be done with the prop `center='vh'`. Shadows can be turned on via 'transparentShadow' or 'shadow`, depending on if the view is transparent or not, respectively. All other props are passed to the `Pressable`, as if you are using it natively. For example, to use this as just a view with centered text, you would specify `center='vh' disabled={true}` as props.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
