### PR TITLE
Fixed list view scroll

### DIFF
--- a/screens/ListViewScreen.tsx
+++ b/screens/ListViewScreen.tsx
@@ -264,13 +264,13 @@ const styles = EStyleSheet.create({
     },
     filterContainer: {
         position: 'absolute',
-        top: '18%',
+        top: '17%',
         width: '100%',
         height: '8.62%',
         justifyContent: 'space-between',
     },
     filterRow: {
-        height: '43.71%',
+        height: '42.5%',
         width: '100%',
         flexDirection: 'row',
         justifyContent: 'center',
@@ -303,14 +303,14 @@ const styles = EStyleSheet.create({
     scrollViewStyle: {
         marginHorizontal: -30,
         marginBottom: -30,
-        marginTop: -30,
+        marginTop: -5,
     },
     scrollViewContent: {
         alignItems: 'center',
         gap: '0.69rem',
         paddingBottom: 30, // must be negative of scrollViewStyle marginBottom above for bottom shadow to show
         paddingHorizontal: 30, // see ^
-        paddingTop: 30,
+        paddingTop: 5,
     },
     cardContainer: {
         width: '83.6%',


### PR DESCRIPTION
## Problem

ScrollView margin hack to show shadows beyond the scroll container went too far for the top, leading to overlap between scroll-end and the filter pills.

## Description of Changes

- Fixed scrolling to end below pills.
- Increased spacing between the rows of pills

![image](https://github.com/ashenafee/STG/assets/45798963/d13494bf-c95e-4e06-b6d9-2f3a6cf46437)

See #26 for previous version screenshots.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
